### PR TITLE
Implement Game Over Screen in Snake Game

### DIFF
--- a/Snake.py
+++ b/Snake.py
@@ -78,8 +78,13 @@ class Snake:
                 image.toggleDot(entry[1],entry[0])
             image.toggleDot(self.fruit[1],self.fruit[0])
             return (image,self.speed)
+        elif self.state == "game_over_screen":
+            image = Image()
+            image.insert_text("Game",(0,8),scale=0.6)
+            image.insert_text("over",(1,15),scale=0.7)
+            self.state = "game_over"
+            return (image, 2)
         elif self.state == "game_over":
-             #return Gameover image TODO
             if self.change_to == 'UP' :
                 name = list(self.name)
                 name[self.nam_at] = chr(ord(self.name[self.nam_at])-1)
@@ -130,7 +135,7 @@ class Snake:
         self.change_to = input
 
     def game_over(self):
-        self.state = "game_over"
+        self.state = "game_over_screen"
         self.change_to = 'NONE'
         self.nam_at = 0
 


### PR DESCRIPTION
This change implements a proper "Game Over" splash screen for the Snake game. 

Previously, when the game ended, it immediately jumped to the high score name entry screen. Now, it displays a "Game over" message (consistent with the style in Pong.py) for 2 seconds before proceeding to the name entry.

Changes:
- Modified `Snake.game_over()` to transition to `game_over_screen`.
- Added logic in `Snake.getframe()` to handle the `game_over_screen` state, rendering the message and setting a 2-second delay.
- Verified state transitions and frame generation with a test script using mocked dependencies.

---
*PR created automatically by Jules for task [6611868337700226079](https://jules.google.com/task/6611868337700226079) started by @breiflor*